### PR TITLE
Revert "Fixed #3 TypeError"

### DIFF
--- a/src/Hooks/GeneratePageHook.php
+++ b/src/Hooks/GeneratePageHook.php
@@ -259,7 +259,7 @@ class GeneratePageHook
 
         if (null !== $arrCookies) {
             $arrResult = [];
-            array_walk($arrCookies, static function ($cookie) use (&$arrResult): void { $arrResult[] = html_entity_decode(str_replace('&#39;', "'", $cookie['key'])); });
+            array_walk($arrCookies, static function ($cookie) use (&$arrResult): void { $arrResult[] = html_entity_decode(str_replace('&#39;', "'", $cookie)); });
             $result = implode(",\n          ", $arrResult);
         }
 


### PR DESCRIPTION
Reverts pdir/klaro-consent-manager#5

The issue was probably caused by a migration error; see https://github.com/pdir/klaro-consent-manager/issues/3